### PR TITLE
Add basic single sign out support for GitHub properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2.0 2015/02/18
+
+* Implement single sign out for cookie sessions of GitHub properties
+
 v1.0.3 2014/12/13
 
 * Reintroduce membership caching to reduce API hits for validating team membership.

--- a/README.md
+++ b/README.md
@@ -156,19 +156,13 @@ class ApplicationController < ActionController::Base
 
   before_filter :verify_logged_in_user
 
-  helper_method :current_user
-
   private
 
   def verify_logged_in_user
-    unless current_user && warden_github_sso_session_valid?(current_user, 30)
+    unless github_user && warden_github_sso_session_valid?(github_user, 120)
       request.env['warden'].logout
       request.env['warden'].authenticate!
     end
-  end
-
-  def current_user
-    github_user
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -143,6 +143,38 @@ If you're looking for an easy way to integrate this into a Sinatra or Rails appl
 - [sinatra_auth_github](https://github.com/atmos/sinatra_auth_github)
 - [warden-github-rails](https://github.com/fphilipe/warden-github-rails)
 
+## Single Sign Out
+
+OAuth applications owned by the GitHub organization are sent an extra browser parameter to ensure that the user remains logged in to github.com. Taking advantage of this is provided by a small module you include into your controller and a before filter. Your `ApplicationController` should resemble something like this.
+
+
+```ruby
+class ApplicationController < ActionController::Base
+  include Warden::GitHub::SSO
+
+  protect_from_forgery with: :exception
+
+  before_filter :verify_logged_in_user
+
+  helper_method :current_user
+
+  private
+
+  def verify_logged_in_user
+    unless current_user && warden_github_sso_session_valid?(current_user, 30)
+      request.env['warden'].logout
+      request.env['warden'].authenticate!
+    end
+  end
+
+  def current_user
+    github_user
+  end
+end
+```
+
+You can also see single sign out in action in the example app.
+
 ## Additional Information
 
 - [warden](https://github.com/hassox/warden)

--- a/example/simple_app.rb
+++ b/example/simple_app.rb
@@ -21,7 +21,7 @@ module Example
     end
 
     def verify_browser_session
-      if env['warden'].user && !env['warden'].user.browser_session_valid?(10)
+      if env['warden'].user && !warden_github_sso_session_valid?(env['warden'].user, 10)
         env['warden'].logout
       end
     end

--- a/example/simple_app.rb
+++ b/example/simple_app.rb
@@ -102,6 +102,6 @@ __END__
     <dt>GitHub Browser Session Valid</dt>
     <dd><%= warden_github_sso_session_valid?(env['warden'].user, 10) %></dd>
     <dt>GitHub Browser Session Verified At</dt>
-    <dd><%= Time.at(session[:warden_github_sso_session_verified_at]) %></dd>
+    <dd><%= Time.at(warden_github_sso_session_verified_at) %></dd>
   <% end %>
 </dl>

--- a/example/simple_app.rb
+++ b/example/simple_app.rb
@@ -2,6 +2,8 @@ require File.expand_path('../setup', __FILE__)
 
 module Example
   class SimpleApp < BaseApp
+    include Warden::GitHub::SSO
+
     enable :inline_templates
 
     GITHUB_CONFIG = {
@@ -98,10 +100,8 @@ __END__
     <dt>GitHub Browser Session ID</dt>
     <dd><%= env['warden'].user.browser_session_id %></dd>
     <dt>GitHub Browser Session Valid</dt>
-    <dd><%= env['warden'].user.browser_session_valid?(10) %></dd>
+    <dd><%= warden_github_sso_session_valid?(env['warden'].user, 10) %></dd>
     <dt>GitHub Browser Session Verified At</dt>
-    <dd><%= Time.at(env['warden'].user.browser_session_verified_at) %></dd>
-    <dt>GitHub Browser Session Needs Reverification</dt>
-    <dd><%= env['warden'].user.needs_browser_reverification?(10) %></dd>
+    <dd><%= Time.at(session[:warden_github_sso_session_verified_at]) %></dd>
   <% end %>
 </dl>

--- a/lib/warden/github.rb
+++ b/lib/warden/github.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'warden'
+require 'octokit'
 
 require 'warden/github/user'
 require 'warden/github/oauth'

--- a/lib/warden/github.rb
+++ b/lib/warden/github.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'warden'
 require 'octokit'
 
+require 'warden/github/sso'
 require 'warden/github/user'
 require 'warden/github/oauth'
 require 'warden/github/version'

--- a/lib/warden/github/sso.rb
+++ b/lib/warden/github/sso.rb
@@ -1,0 +1,30 @@
+module Warden
+  module GitHub
+    module SSO
+      def warden_github_sso_session_valid?(user, expiry_in_seconds = 30)
+        return true if defined?(::Rails) && ::Rails.env.test?
+        if warden_github_sso_session_needs_reverification?(user, expiry_in_seconds)
+          if user.browser_session_valid?(expiry_in_seconds)
+            warden_github_sso_session_reverify!
+            return true
+          end
+          return false
+        end
+        true
+      end
+
+      def warden_github_sso_session_verified_at
+        session[:warden_github_sso_session_verified_at] || Time.now.utc.to_i - 86400
+      end
+
+      def warden_github_sso_session_reverify!
+        session[:warden_github_sso_session_verified_at] = Time.now.utc.to_i
+      end
+
+      def warden_github_sso_session_needs_reverification?(user, expiry_in_seconds)
+        user.using_single_sign_out? &&
+          (warden_github_sso_session_verified_at <= (Time.now.utc.to_i - expiry_in_seconds))
+      end
+    end
+  end
+end

--- a/lib/warden/github/strategy.rb
+++ b/lib/warden/github/strategy.rb
@@ -70,6 +70,10 @@ module Warden
         elsif (error = params['error']) && !error.empty?
           abort_flow!(error.gsub(/_/, ' '))
         end
+
+        if params['browser_session_id']
+          custom_session['browser_session_id'] = params['browser_session_id']
+        end
       end
 
       def custom_session
@@ -77,7 +81,7 @@ module Warden
       end
 
       def load_user
-        User.load(oauth.access_token)
+        User.load(oauth.access_token, custom_session['browser_session_id'])
       rescue OAuth::BadVerificationCode => e
         abort_flow!(e.message)
       end

--- a/lib/warden/github/user.rb
+++ b/lib/warden/github/user.rb
@@ -1,11 +1,9 @@
-require 'octokit'
-
 module Warden
   module GitHub
-    class User < Struct.new(:attribs, :token)
+    class User < Struct.new(:attribs, :token, :browser_session_id, :browser_session_verified_at)
       ATTRIBUTES = %w[id login name gravatar_id avatar_url email company site_admin].freeze
 
-      def self.load(access_token)
+      def self.load(access_token, browser_session_id = nil)
         api  = Octokit::Client.new(:access_token => access_token)
         data =  { }
 
@@ -13,7 +11,7 @@ module Warden
           data[k.to_s] = v if ATTRIBUTES.include?(k.to_s)
         end
 
-        new(data, access_token)
+        new(data, access_token, browser_session_id, Time.now.utc.to_i)
       end
 
       def marshal_dump
@@ -69,6 +67,41 @@ module Warden
       # Returns: true if the authenticated user is a GitHub employee, false otherwise
       def site_admin?
         !!site_admin
+      end
+
+      # Identify if the browser session is still valid
+      #
+      # Returns: true if the browser session is still active or the GitHub API is unavailable
+      def browser_session_valid?(since = 120)
+        return true unless needs_browser_reverification?(since)
+        client = api
+        client.get("/user/sessions/active", :browser_session_id => browser_session_id)
+        self.browser_session_verified_at = Time.now.utc.to_i
+        client.last_response.status == 204
+      rescue Octokit::ServerError # GitHub API unavailable
+        true
+      rescue Octokit::ClientError => e # GitHub API failed
+        false
+      end
+
+      # Identify whether or not the browser has been reverified since a time
+      #
+      # since - The number of seconds since the last browser session verification
+      #
+      # Returns: true if the user is using single signout and needs to be
+      # reverified. false if it has been verified in a recent enough amount of
+      # time.
+      def needs_browser_reverification?(since = 120)
+        return false unless using_single_sign_out?
+        browser_session_verified_at &&
+          (browser_session_verified_at <= (Time.now.utc.to_i - since))
+      end
+
+      # Identify if the user is on a GitHub SSO property
+      #
+      # Returns: true if a browser_session_id is present, false otherwise.
+      def using_single_sign_out?
+        !(browser_session_id.nil? || browser_session_id == "")
       end
 
       # Access the GitHub API from Octokit

--- a/lib/warden/github/version.rb
+++ b/lib/warden/github/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module GitHub
-    VERSION = "1.1.1"
+    VERSION = "1.2.0.pre1"
   end
 end

--- a/lib/warden/github/version.rb
+++ b/lib/warden/github/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module GitHub
-    VERSION = "1.2.0.pre1"
+    VERSION = "1.2.0.pre2"
   end
 end

--- a/lib/warden/github/version.rb
+++ b/lib/warden/github/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module GitHub
-    VERSION = "1.2.0.pre2"
+    VERSION = "1.2.0"
   end
 end

--- a/spec/integration/oauth_spec.rb
+++ b/spec/integration/oauth_spec.rb
@@ -100,6 +100,23 @@ describe 'OAuth' do
         authenticated_uri.query.should eq 'foo=bar'
       end
     end
+
+    context 'with GitHub SSO and code was exchanged for an access token' do
+      it 'redirects back to the original path' do
+        stub_code_for_token_exchange
+        stub_user_retrieval
+
+        unauthenticated_response = get '/profile?foo=bar'
+        github_uri = redirect_uri(unauthenticated_response)
+        state = github_uri.query_values['state']
+
+        callback_response = get "/profile?code=#{code}&state=#{state}&browser_session_id=abcdefghijklmnop"
+        authenticated_uri = redirect_uri(callback_response)
+
+        authenticated_uri.path.should eq '/profile'
+        authenticated_uri.query.should eq 'foo=bar'
+      end
+    end
   end
 
   context 'when not inside OAuth flow' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ SimpleCov.start do
   add_filter '/example'
 end
 
+require 'pry'
 require 'warden/github'
 require File.expand_path('../../example/simple_app', __FILE__)
 require 'rack/test'
@@ -15,5 +16,10 @@ RSpec.configure do |config|
 
   def app
     Example.app
+  end
+
+  def stub_user_session_request
+    stub_request(:get, "https://api.github.com/user/sessions/active?browser_session_id=abcdefghijklmnop").
+      with(:headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'token the_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 3.7.0'})
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ SimpleCov.start do
   add_filter '/example'
 end
 
-require 'pry'
 require 'warden/github'
 require File.expand_path('../../example/simple_app', __FILE__)
 require 'rack/test'
@@ -20,6 +19,6 @@ RSpec.configure do |config|
 
   def stub_user_session_request
     stub_request(:get, "https://api.github.com/user/sessions/active?browser_session_id=abcdefghijklmnop").
-      with(:headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'token the_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 3.7.0'})
+      with(:headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'token the_token', 'Content-Type'=>'application/json', 'User-Agent'=>"Octokit Ruby Gem #{Octokit::VERSION}"})
   end
 end

--- a/spec/unit/sso_spec.rb
+++ b/spec/unit/sso_spec.rb
@@ -25,7 +25,7 @@ describe Warden::GitHub::SSO do
     FakeController.new
   end
 
-  describe "whatever" do
+  describe "warden_github_sso_session_valid?" do
     it "identifies when browsers need to be reverified" do
       subject.session[:warden_github_sso_session_verified_at] = Time.now.utc.to_i - 10
       subject.should be_warden_github_sso_session_valid(user)

--- a/spec/unit/sso_spec.rb
+++ b/spec/unit/sso_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+class FakeController
+  def session
+    @session ||= {}
+  end
+  include Warden::GitHub::SSO
+end
+
+describe Warden::GitHub::SSO do
+  let(:default_attrs) do
+    { 'login' => 'john',
+      'name' => 'John Doe',
+      'gravatar_id' => '38581cb351a52002548f40f8066cfecg',
+      'avatar_url' => 'http://example.com/avatar.jpg',
+      'email' => 'john@doe.com',
+      'company' => 'Doe, Inc.' }
+  end
+
+  let(:user) do
+    Warden::GitHub::User.new(default_attrs, "the_token", "abcdefghijklmnop")
+  end
+
+  subject do
+    FakeController.new
+  end
+
+  describe "whatever" do
+    it "identifies when browsers need to be reverified" do
+      subject.session[:warden_github_sso_session_verified_at] = Time.now.utc.to_i - 10
+      subject.should be_warden_github_sso_session_valid(user)
+
+      subject.session[:warden_github_sso_session_verified_at] = Time.now.utc.to_i - 300
+      stub_user_session_request.to_return(:status => 204, :body => "", :headers => {})
+      subject.should be_warden_github_sso_session_valid(user)
+
+      subject.session[:warden_github_sso_session_verified_at] = Time.now.utc.to_i - 300
+      stub_user_session_request.to_return(:status => 404, :body => "", :headers => {})
+      subject.should_not be_warden_github_sso_session_valid(user)
+    end
+  end
+end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -16,7 +16,7 @@ describe Warden::GitHub::User do
   end
 
   let(:sso_user) do
-    described_class.new(default_attrs, token, "abcdefghijklmnop", Time.now.utc.to_i)
+    described_class.new(default_attrs, token, "abcdefghijklmnop")
   end
 
   describe '#token' do
@@ -119,37 +119,23 @@ describe Warden::GitHub::User do
       sso_user.should be_using_single_sign_out
     end
 
-    it "identifies when browsers need to be reverified" do
-      sso_user.should_not be_needs_browser_reverification
-      sso_user.browser_session_verified_at = Time.now.utc.to_i - 300
-      sso_user.should be_needs_browser_reverification
-    end
-
     context "browser reverification" do
-      before do
-        sso_user.browser_session_verified_at = Time.now.utc.to_i - 300
-      end
-
       it "handles success" do
-        sso_user.should be_needs_browser_reverification
         stub_user_session_request.to_return(:status => 204, :body => "", :headers => {})
         sso_user.should be_browser_session_valid
       end
 
       it "handles failure" do
-        sso_user.should be_needs_browser_reverification
-        stub_user_session_request.to_return(:status => 403, :body => "", :headers => {})
+        stub_user_session_request.to_return(:status => 404, :body => "", :headers => {})
         sso_user.should_not be_browser_session_valid
       end
 
       it "handles GitHub being unavailable" do
-        sso_user.should be_needs_browser_reverification
         stub_user_session_request.to_raise(Octokit::ServerError.new)
         sso_user.should be_browser_session_valid
       end
 
       it "handles authentication failures" do
-        sso_user.should be_needs_browser_reverification
         stub_user_session_request.to_return(:status => 403, :body => "", :headers => {})
         sso_user.should_not be_browser_session_valid
       end


### PR DESCRIPTION
This uses an internal API that we're evaluating to give people easier single sign out for OAuth clients using cookie sessions. This is only available to GitHub owned OAuth apps, and shouldn't have any adverse effects for everyone else's clients.

Here's how it works:

* During the OAuth callback phase an extra parameter is returned to the handshake, `browser_session_id`. This is stored on the user object for later use.
* GitHub has an API available `/user/sessions/active` that accepts OAuth tokens and the `browser_session_id`. Given these two values GitHub can determine if the initiating browser still has a valid session and returns true or false depending on whether it's still valid on the site.
* Browser sessions can be verified periodically in a before filter to ensure that the user should still have access to the site. By default the check ensures that the user has been verified in the last 2 minutes.

I'm gonna fix up the example app and start rolling this out to a few apps before merging and releasing.

