### PR TITLE
Allow absolute redirect URIs

### DIFF
--- a/lib/warden/github/config.rb
+++ b/lib/warden/github/config.rb
@@ -113,8 +113,12 @@ module Warden
       end
 
       def normalized_uri(uri_or_path)
-        uri = URI(request.url)
-        uri.path = extract_path(URI(uri_or_path))
+        uri = URI(uri_or_path)
+        unless uri.absolute?
+          path = extract_path(uri)
+          uri = URI(request.url)
+          uri.path = path
+        end
         uri.query = nil
         uri.fragment = nil
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -113,6 +113,13 @@ describe Warden::GitHub::Config do
       end
     end
 
+    context 'when specified as an absolute uri' do
+      it 'retains the original uri but strips query and fragment' do
+        scope_config[:redirect_uri] = 'http://test1.example.com/callback?x=y#1'
+        config.redirect_uri.should eq 'http://test1.example.com/callback'
+      end
+    end
+
     context 'when specified in deprecated config' do
       it 'returns the expanded redirect uri' do
         warden_config[:github_callback_url] = '/callback'


### PR DESCRIPTION
Currently, when you configure a `redirect_uri` that is an absolute URI, it has its path extracted and appended to the request domain to create the actual `redirect_uri` sent to Github. So, for example, if you have a `redirect_uri` of `test1.example.com/callback` but your app runs on `test2.example.com`, the `redirect_uri` sent to Github will be `test2.example.com/callback`. In most cases, this is the intended behavior, since Github doesn't allow redirect URIs that aren't extensions of the callback URI.

This patch allows `redirect_uri`s that are specified as absolute URIs to retain their domains, which allows, for example, OAuth schemes where a single app is the "OAuth broker" for several other apps. See http://stackoverflow.com/a/13841857 for an example. Using this patch, I was able to set up a single OAuth broker for many apps as described in the example.

A little background to motivate why you would ever want to do this: we have a simple database admin app that takes, as configuration, a single connection url. For any database, say, db1, we expose this admin app on its own subdomain, e.g.,  `db1.example.com`. We have dozens of these admin apps and don't want to create a Github OAuth config for each individual one, so instead we set up a single `db.example.com` app as the "broker". When a request comes in to `db1.example.com` that needs authorization, it hits the Github OAuth endpoint with a `redirect_uri` of `db.example.com/auth/github/callback/db1.example.com`. When `db.example.com` gets the call back from Github on that path, it just fowards it (along with the `code` and `state`) back to `db1.example.com/auth/github/callback`, which checks the `state` and finishes the OAuth flow.