### PR TITLE
Improve JSON serialization compatibility of User

### DIFF
--- a/lib/warden/github/membership_cache.rb
+++ b/lib/warden/github/membership_cache.rb
@@ -3,8 +3,12 @@ module Warden
     # A hash subclass that acts as a cache for organization and team
     # membership states. Only membership states that are true are cached. These
     # are invalidated after a certain time.
-    class MembershipCache < ::Hash
+    class MembershipCache
       CACHE_TIMEOUT = 60 * 5
+
+      def initialize(data)
+        @data = data
+      end
 
       # Fetches a membership status by type and id (e.g. 'org', 'my_company')
       # from cache. If no cached value is present or if the cached value
@@ -27,10 +31,10 @@ module Warden
       private
 
       def cached_membership_valid?(type, id)
-        timestamp = fetch(type).fetch(id)
+        timestamp = @data.fetch(type).fetch(id)
 
         if Time.now.to_i > timestamp + CACHE_TIMEOUT
-          fetch(type).delete(id)
+          @data.fetch(type).delete(id)
           false
         else
           true
@@ -40,7 +44,7 @@ module Warden
       end
 
       def cache_membership(type, id)
-        hash = self[type] ||= {}
+        hash = @data[type] ||= {}
         hash[id] = Time.now.to_i
       end
     end

--- a/spec/unit/membership_cache_spec.rb
+++ b/spec/unit/membership_cache_spec.rb
@@ -1,19 +1,17 @@
 require 'spec_helper'
 
 describe Warden::GitHub::MembershipCache do
-  subject(:cache) do
-    described_class.new
-  end
-
   describe '#fetch_membership' do
     it 'returns false by default' do
+      cache = described_class.new({})
       cache.fetch_membership('foo', 'bar').should be_falsey
     end
 
     context 'when cache valid' do
-      before do
-        cache['foo'] = {}
-        cache['foo']['bar'] = Time.now.to_i - described_class::CACHE_TIMEOUT + 5
+      let(:cache) do
+        described_class.new('foo' => {
+          'bar' => Time.now.to_i - described_class::CACHE_TIMEOUT + 5
+        })
       end
 
       it 'returns true' do
@@ -27,20 +25,16 @@ describe Warden::GitHub::MembershipCache do
     end
 
     context 'when cache expired' do
-      before do
-        cache['foo'] = {}
-        cache['foo']['bar'] = Time.now.to_i - described_class::CACHE_TIMEOUT - 5
+      let(:cache) do
+        described_class.new('foo' => {
+          'bar' => Time.now.to_i - described_class::CACHE_TIMEOUT - 5
+        })
       end
 
       context 'when no block given' do
         it 'returns false' do
           cache.fetch_membership('foo', 'bar').should be_falsey
         end
-      end
-
-      it 'deletes the cached value' do
-        cache.fetch_membership('foo', 'bar')
-        cache['foo'].should_not have_key('bar')
       end
 
       it 'invokes the block' do
@@ -50,13 +44,40 @@ describe Warden::GitHub::MembershipCache do
     end
 
     it 'caches the value when block returns true' do
+      cache = described_class.new({})
       cache.fetch_membership('foo', 'bar') { true }
       cache.fetch_membership('foo', 'bar').should be_truthy
     end
 
     it 'does not cache the value when block returns false' do
+      cache = described_class.new({})
       cache.fetch_membership('foo', 'bar') { false }
       cache.fetch_membership('foo', 'bar').should be_falsey
     end
+  end
+
+  it 'uses the hash that is passed to the initializer as storage' do
+    time = Time.now.to_i
+    hash = {
+      'foo' => {
+        'valid' => time,
+        'timedout' => time - described_class::CACHE_TIMEOUT - 5
+      }
+    }
+    cache = described_class.new(hash)
+
+    # Verify that existing data in the hash is used:
+    expect(cache.fetch_membership('foo', 'valid')).to be_true
+    expect(cache.fetch_membership('foo', 'timedout')).to be_false
+
+    # Add new data to the hash:
+    cache.fetch_membership('foo', 'new') { true }
+    cache.fetch_membership('foo', 'false') { false }
+
+    # Verify the final hash state:
+    expect(hash).to eq('foo' => {
+      'valid' => time,
+      'new' => time
+    })
   end
 end


### PR DESCRIPTION
Previously, the `MembershipCache` was a subclass of `Hash`. When serializing to and deserializing from JSON, the `MembershipCache` would become a `Hash` and blow up. This is a problem in warden-github-rails where I switched to a custom warden (de)serialization in order to properly support JSON serialization and also to support mocked users in test environments between requests (relevant [warden-github-rails commit][1]).

[1]: https://github.com/fphilipe/warden-github-rails/commit/db82470e6fa66b0b546cfef501abcd04f91529ca