### PR TITLE
Always use strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
   - 2.3.0
-  - ruby-head

--- a/lib/warden/github/membership_cache.rb
+++ b/lib/warden/github/membership_cache.rb
@@ -16,7 +16,7 @@ module Warden
       # cached for e certain time.
       def fetch_membership(type, id)
         type = type.to_s
-        id = id.to_s if id.is_a?(Symbol)
+        id = id.to_s
 
         if cached_membership_valid?(type, id)
           true

--- a/lib/warden/github/version.rb
+++ b/lib/warden/github/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module GitHub
-    VERSION = "1.3.0"
+    VERSION = "1.3.1"
   end
 end

--- a/spec/unit/membership_cache_spec.rb
+++ b/spec/unit/membership_cache_spec.rb
@@ -22,6 +22,10 @@ describe Warden::GitHub::MembershipCache do
         expect { |b| cache.fetch_membership('foo', 'bar', &b) }.
           to_not yield_control
       end
+
+      it 'converts type and id to strings' do
+        cache.fetch_membership(:foo, :bar).should be_truthy
+      end
     end
 
     context 'when cache expired' do


### PR DESCRIPTION
This fixes a really difficult issue to track down, particularly when the
user specifies a GitHub team as an integer instead of a string. The
resulting API call includes a string, but the cache will be an integer.
As such, it will always force a cache lookup.