### PR TITLE
Persist membership cache between requests

### DIFF
--- a/lib/warden/github/hook.rb
+++ b/lib/warden/github/hook.rb
@@ -4,3 +4,10 @@ Warden::Manager.after_authentication do |user, auth, opts|
 
   strategy.finalize_flow!  if strategy.class == Warden::GitHub::Strategy
 end
+
+Warden::Manager.after_set_user do |user, auth, opts|
+  if user.is_a?(Warden::GitHub::User)
+    session = auth.session(opts.fetch(:scope))
+    user.memberships = session[:_memberships] ||= {}
+  end
+end

--- a/lib/warden/github/user.rb
+++ b/lib/warden/github/user.rb
@@ -1,7 +1,9 @@
 module Warden
   module GitHub
-    class User < Struct.new(:attribs, :token, :browser_session_id, :memberships)
+    class User < Struct.new(:attribs, :token, :browser_session_id)
       ATTRIBUTES = %w[id login name gravatar_id avatar_url email company site_admin].freeze
+
+      attr_accessor :memberships
 
       def self.load(access_token, browser_session_id = nil)
         api  = Octokit::Client.new(:access_token => access_token)

--- a/lib/warden/github/version.rb
+++ b/lib/warden/github/version.rb
@@ -1,5 +1,5 @@
 module Warden
   module GitHub
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end


### PR DESCRIPTION
The membership cache was being serialized into the user object. It was assumed that the user object was serialized at the end of each request. It turns out that this is not the case. Instead, the user object only gets serialized once, namely after setting the user. This means that the membership cache wasn't working at all between requests.

This commit fixes it by not including the memberships in the serialized user as there's no point in doing so. Instead, after the user object is set up, the memberships hash get retrieved from the user session (warden provides a session object for each scope; if there is none, a new hash is stored in the session) and assigned to the user object. The hash is
then used as before and we get the session serialization from rack for free.

Fixes #52.